### PR TITLE
Fix extra "event" typo

### DIFF
--- a/105/events-subscriber.py
+++ b/105/events-subscriber.py
@@ -12,7 +12,7 @@ async def subs():
     async with get_events_subscriber() as subscriber:
         async for event in subscriber:
             print(f"📬 Received event {event.event!r}")
-            seen_events.add(event.event.event)
+            seen_events.add(event.event)
             if len(seen_events) > 5:
                 break
 


### PR DESCRIPTION
There was an extra `event` in `event.event` making it `event.event.event` which is 1 too many `event`s so this PR removes an `event` to make `event.event.event` just `event.event`, solving the error event: 

![image](https://github.com/user-attachments/assets/61965665-c8bc-4447-9a13-0de2773e9f46)
